### PR TITLE
Remove iframe token renew (use refresh token)

### DIFF
--- a/build/webpack.config.base.js
+++ b/build/webpack.config.base.js
@@ -16,7 +16,6 @@ const utils = require('./utils')
 module.exports = {
   entry: {
     main: './src/main.js',
-    oidcRenew: './src/oidc-silent-renew.js'
   },
 
   resolve: {
@@ -94,12 +93,6 @@ module.exports = {
       template: 'index.html',
       chunks: ['main'],
       inject: true
-    }),
-    new HtmlWebpackPlugin({
-      filename: 'oidc-silent-renew.html',
-      template: 'oidc-silent-renew.html',
-      chunks: ['oidcRenew'],
-      inject: 'head'
     }),
     new VueLoaderPlugin(),
     new CopyWebpackPlugin([

--- a/src/config/OIDCSettings.js
+++ b/src/config/OIDCSettings.js
@@ -11,7 +11,6 @@ export const oidcSettings = {
   scope: 'openid profile email',
   revokeAccessTokenOnSignout: true,
   automaticSilentRenew: true,
-  silentRedirectUri: process.env.BD_APP_URL + '/oidc-silent-renew.html',
   validateSubOnSilentRenew: true,
   extraQueryParams: {kc_idp_hint: 'bimdataconnect'},
   clockSkew: 900

--- a/src/oidc-silent-renew.js
+++ b/src/oidc-silent-renew.js
@@ -1,8 +1,0 @@
-/* This file is part of the BIMData Platform package.
-(c) BIMData support@bimdata.io
-For the full copyright and license information, please view the LICENSE
-file that was distributed with this source code. */
-import { vuexOidcProcessSilentSignInCallback } from 'vuex-oidc'
-import { oidcSettings } from '@/config/OIDCSettings'
-
-vuexOidcProcessSilentSignInCallback(oidcSettings)

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -13,15 +13,6 @@ import { oidcSettings } from '@/config/OIDCSettings'
 
 Vue.use(Vuex)
 
-let vuexOidcStorage = vuexOidcCreateStoreModule(oidcSettings)
-let originalMethod = vuexOidcStorage.actions.authenticateOidc
-vuexOidcStorage.actions.authenticateOidc = function authenticateOidc (context, redirectPath) {
-  Object.keys(localStorage)
-    .filter(entry => entry.startsWith('oidc.'))
-    .forEach(entry => localStorage.removeItem(entry))
-  originalMethod(context, redirectPath)
-}
-
 const store = new Vuex.Store({
   state: {
     isAuthenticated: false,
@@ -35,7 +26,7 @@ const store = new Vuex.Store({
     clouds: []
   },
   modules: {
-    oidc: vuexOidcStorage,
+    oidc: vuexOidcCreateStoreModule(oidcSettings),
     project: ProjectModule
   },
   mutations,


### PR DESCRIPTION
## Description
Authorization code + PKCE provides a refresh token that is used automatically by oidc-client. Therefore, we don't need to setup a silent-renew iframe.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
